### PR TITLE
"golang.org/x/tools/go/types" -> "go/types"

### DIFF
--- a/check.go
+++ b/check.go
@@ -2,16 +2,17 @@ package unexport
 
 import (
 	"fmt"
-	"github.com/isaiah/unexport/lexical"
 	"go/ast"
 	"go/token"
-	"golang.org/x/tools/go/loader"
-	"golang.org/x/tools/go/types"
-	"golang.org/x/tools/go/types/typeutil"
-	"golang.org/x/tools/refactor/satisfy"
+	"go/types"
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/isaiah/unexport/lexical"
+	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/go/types/typeutil"
+	"golang.org/x/tools/refactor/satisfy"
 )
 
 // Content of this file is copy & pasted from x/tools/refactor/rename,

--- a/cmd/unexport/main.go
+++ b/cmd/unexport/main.go
@@ -4,16 +4,17 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/isaiah/unexport"
 	"go/build"
-	"golang.org/x/tools/go/buildutil"
-	"golang.org/x/tools/go/types"
+	"go/types"
 	"log"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
 	t "runtime/trace"
 	"strings"
+
+	"github.com/isaiah/unexport"
+	"golang.org/x/tools/go/buildutil"
 )
 
 var (

--- a/lexical/lexical.go
+++ b/lexical/lexical.go
@@ -36,7 +36,7 @@ import (
 	"os"
 	"strconv"
 
-	"golang.org/x/tools/go/types"
+	"go/types"
 )
 
 const trace = false

--- a/unexport.go
+++ b/unexport.go
@@ -3,18 +3,19 @@ package unexport
 import (
 	"bytes"
 	"fmt"
-	"github.com/isaiah/unexport/lexical"
 	"go/ast"
 	"go/build"
 	"go/format"
 	"go/parser"
 	"go/token"
-	"golang.org/x/tools/go/loader"
-	"golang.org/x/tools/go/types"
-	"golang.org/x/tools/refactor/importgraph"
+	"go/types"
 	"io/ioutil"
 	"log"
 	"sort"
+
+	"github.com/isaiah/unexport/lexical"
+	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/refactor/importgraph"
 )
 
 var (

--- a/unexport_test.go
+++ b/unexport_test.go
@@ -3,12 +3,13 @@ package unexport
 import (
 	"fmt"
 	"go/build"
-	"golang.org/x/tools/go/buildutil"
-	"golang.org/x/tools/go/loader"
-	"golang.org/x/tools/go/types"
+	"go/types"
 	"reflect"
 	"strings"
 	"testing"
+
+	"golang.org/x/tools/go/buildutil"
+	"golang.org/x/tools/go/loader"
 )
 
 func TestUsedIdentifiers(t *testing.T) {

--- a/util.go
+++ b/util.go
@@ -2,10 +2,11 @@ package unexport
 
 import (
 	"fmt"
-	"golang.org/x/tools/go/loader"
-	"golang.org/x/tools/go/types"
+	"go/types"
 	"unicode"
 	"unicode/utf8"
+
+	"golang.org/x/tools/go/loader"
 )
 
 func wholePath(obj types.Object, path string, prog *loader.Program) string {


### PR DESCRIPTION
This fixes the build at least for the latest version of Go. I'm not sure which version moved the package.

Should address #3.